### PR TITLE
Fix dom not change while data change

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -320,7 +320,7 @@ export default defineComponent({
         oldOffset = null;
         recomputeSizes();
         setDomStyle();
-        setTimeout(scrollRender, 0);
+        scrollRender()
       }
     );
 


### PR DESCRIPTION
As https://github.com/tnfe/vue3-infinite-list/issues description.
I fix `setTimeout` to directly run `scrollRender()`.

There may be some doubts about whether the `renderEnd` function can be removed from the `scrollRender` function and run separately (involving many changes). 

I see that other `watch` run `scrollRender` directly. So I haven't made too many modifications here either. 

If there is indeed an impact (it operates on DOM), the `renderEnd` function can be removed from the `scrollRender` function. 
And run `renderEnd` in `watch` or some other places.